### PR TITLE
Add docs around Profiling

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -61,7 +61,7 @@ def test(coverage, test_names):
               help='Directory where profiler data files are saved.')
 def profile(length, profile_dir):
     """Start the application under the code profiler."""
-    from werkzeug.contrib.profiler import ProfilerMiddleware
+    from werkzeug.middleware.profiler import ProfilerMiddleware
     app.wsgi_app = ProfilerMiddleware(app.wsgi_app, restrictions=[length],
                                       profile_dir=profile_dir)
     app.run()

--- a/profiling/readme.md
+++ b/profiling/readme.md
@@ -9,7 +9,7 @@ manage.py profile
 ## Running the perf test
 The performance tests are designed to hit the APIs using the [Vegeta utility](https://github.com/tsenart/vegeta)
 
-The [request](./request) file contains the APIs that would be hit as part of the performance test. The headers and body parameters can also be configured in here. The parameters if any can be configured in different files. For instance the [vote.json](./vote.json) contains the body params used for making the `/api/vote/` request.
+The [requests](./requests) file contains the APIs that would be hit as part of the performance test. The headers and body parameters can also be configured in here. The parameters if any can be configured in different files. For instance the [vote.json](./vote.json) contains the body params used for making the `/api/vote/` request.
 
 The perf test itself can be run as follows:
 ```

--- a/profiling/readme.md
+++ b/profiling/readme.md
@@ -1,0 +1,27 @@
+# Profiling Streetwise
+
+## Enabling the profiler
+The application can be run with profile enabled as follows:
+```shell
+manage.py profile
+```
+
+## Running the perf test
+The performance tests are designed to hit the APIs using the [Vegeta utility](https://github.com/tsenart/vegeta)
+
+The [request](./request) file contains the APIs that would be hit as part of the performance test. The headers and body parameters can also be configured in here. The parameters if any can be configured in different files. For instance the [vote.json](./vote.json) contains the body params used for making the `/api/vote/` request.
+
+The perf test itself can be run as follows:
+```
+cat requests | vegeta attack -duration=20s -rate=1 > results
+```
+This will run the perf test at the break neck speed of 1 request per second for 20 seconds.
+
+## Creating Graphs / Metrics out of resultset
+### metrics
+```
+vegeta report -type=json results > metrics.json
+```
+### graphs
+cat results | vegeta plot > latency.html
+```

--- a/profiling/requests
+++ b/profiling/requests
@@ -1,0 +1,5 @@
+GET http://localhost:5000/api/image/random
+
+POST http://localhost:5000/api/vote/
+Content-Type: application/json
+@./vote.json

--- a/profiling/vote.json
+++ b/profiling/vote.json
@@ -1,0 +1,10 @@
+{
+    "session_hash": "017581c713f3db95cd45346e2dd1592d",
+    "choice_id": 3840,
+    "other_id": 1171,
+    "is_leftimage": true,
+    "is_undecided": false,
+    "time_elapsed": 7,
+    "window_width": 1920,
+    "window_height": 438
+}


### PR DESCRIPTION
- The `werkzeug.contrib.profiler` has been deprecated in the latest version of werkzeug. Fix that.
- Add docs around running perf test with Vegeta