### PR TITLE
Use custom domain for Fathom analytics script injection

### DIFF
--- a/app.json
+++ b/app.json
@@ -22,6 +22,10 @@
       "description": "API Key",
       "generator": "secret"
     },
+    "VUE_APP_FATHOM_ANALYTICS_URL": {
+      "description": "Fathom analytics URL",
+      "generator": "secret"
+    },
     "VUE_APP_FATHOM_ANALYTICS_CODE": {
       "description": "Fathom analytics API Key",
       "generator": "secret"

--- a/src/App.vue
+++ b/src/App.vue
@@ -13,7 +13,7 @@ export default {
     script: [{
       // Add the fathom analytics script to the webpage
       // The site code will be injected by config vars at runtime
-      src: 'https://lemur.streetwise-app.ch/script.js',
+      src: process.env.VUE_APP_FATHOM_ANALYTICS_URL,
       site: process.env.VUE_APP_FATHOM_ANALYTICS_CODE,
       async: true,
       defer: true

--- a/src/App.vue
+++ b/src/App.vue
@@ -13,7 +13,7 @@ export default {
     script: [{
       // Add the fathom analytics script to the webpage
       // The site code will be injected by config vars at runtime
-      src: 'https://cdn.usefathom.com/3.js',
+      src: 'https://lemur.streetwise-app.ch/script.js',
       site: process.env.VUE_APP_FATHOM_ANALYTICS_CODE,
       async: true,
       defer: true


### PR DESCRIPTION
Allows us to use custom domains for our analytics, improving the integration.

See also #36