### PR TITLE
Added caching of image tracker

### DIFF
--- a/streetwise/api/helper/image_tracker.py
+++ b/streetwise/api/helper/image_tracker.py
@@ -77,7 +77,7 @@ def select_least_displayed(how_many, sorted_image_list):
     """
     imageSorted = sorted_image_list[0 : how_many]
     if len(sorted_image_list) >= how_many*3:
-        remaining = sorted_image_list[how_many+1]
+        remaining = sorted_image_list[how_many+1:]
     else:
         remaining = None
     print(imageSorted)

--- a/streetwise/api/images.py
+++ b/streetwise/api/images.py
@@ -64,7 +64,8 @@ class ImageRandom(Resource):
         # Retrieve a random selection
         q = q.order_by(func.random()).limit(IMAGES_RANDOM_WALK).all()
         # Obtain the two least tracked images from the selection
-        img2 = least_displayed_images(2, q, campaign_id, g.image_counter)
+        img2, queue = least_displayed_images(2, q, campaign_id, g.image_counter)
+        g.image_counter.queue = queue
         return img2, 201
 
 @ns.route('/<int:image_id>')

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -14,20 +14,20 @@ def client():
 def test_image_counter(client):
     with app_context:
         # Create some images and vote on them
-        campaign1 = Campaign()
-        db.session.add(campaign1)
+        campaign = Campaign()
+        db.session.add(campaign)
         images = [
-            Image(campaign=campaign1, key=str(i))
+            Image(campaign=campaign, key=str(i))
             for i in range(0,5)
         ]
         [ db.session.add(img) for img in images ]
         vote1 = Vote(
-            campaign=campaign1,
+            campaign=campaign,
             choice=images[1], other=images[2]
         )
         db.session.add(vote1)
         vote2 = Vote(
-            campaign=campaign1,
+            campaign=campaign,
             choice=images[3], other=images[4]
         )
         db.session.add(vote2)
@@ -36,8 +36,12 @@ def test_image_counter(client):
         image_tracker.init_image_counter()
         # print(image_tracker.IMAGE_COUNTER_DICT)
 
-        resp = client.get('/api/image/random/%d' % campaign1.id)
+        resp = client.get('/api/image/random/%d' % campaign.id)
         assert resp.status_code == 201
 
         result = json.loads(resp.data)
         assert images[0].id in (result[0]['id'], result[1]['id'])
+
+        for i in range(0, 3):
+            resp = client.get('/api/image/random/%d' % campaign.id)
+            assert resp.status_code == 201


### PR DESCRIPTION
To address #57 I've created an object to contain both the counter and the queue, which is reduced every time images are requested, and reset when it is empty.