### PR TITLE
Change the order in which campaigns are served

### DIFF
--- a/src/components/ImageVote.vue
+++ b/src/components/ImageVote.vue
@@ -113,7 +113,7 @@ export default {
       return this.imageLeft !== 0 && this.imageRight !== 0
     },
     checkVotesComplete () {
-      if (this.voteCount >= this.votesrequired) {
+      if (this.voteCount > this.votesrequired) {
         if (this.skipcomplete && this.skipfeedback) {
           const voter = this
           this.voteCount = 0

--- a/streetwise/api/campaigns.py
+++ b/streetwise/api/campaigns.py
@@ -31,14 +31,14 @@ current_campaign = None
 
 def getCampaign(campaign_id):
     campaign = None
-    query = Campaign.query.order_by(Campaign.id.asc())
+    query = Campaign.query.order_by(Campaign.id.desc())
     # Select the next campaign in sequence if one is provided
     if campaign_id is not None:
         if isinstance(campaign_id, str) and campaign_id.isdigit():
             campaign_id = int(campaign_id)
-            campaign = query.filter(Campaign.id > campaign_id).first()
+            campaign = query.filter(Campaign.id < campaign_id).first()
         if isinstance(campaign_id, int):
-            campaign = query.filter(Campaign.id > campaign_id).first()
+            campaign = query.filter(Campaign.id < campaign_id).first()
     # Otherwise take the first campaign in the list
     if campaign_id is None or campaign is None:
         campaign = query.first()


### PR DESCRIPTION
This change allows us to serve atmosphere campaign as the first
campaign followed by safety. This will help us collect more votes
for the atmosphere campaign.